### PR TITLE
Added scripts to assess sanitize the centroids file

### DIFF
--- a/00_data/centroids_assessment_summary.json
+++ b/00_data/centroids_assessment_summary.json
@@ -4,6 +4,6 @@
   "n_total_raw": 2313805,
   "n_remove_not_in_ebd": 19227,
   "n_keep_from_original": 2255901,
-  "n_swap_and_keep": 781,
-  "n_remove_outside_india": 37896
+  "n_swap_and_keep": 772,
+  "n_remove_outside_india": 37905
 }

--- a/00_data/centroids_assessment_summary.json
+++ b/00_data/centroids_assessment_summary.json
@@ -1,0 +1,9 @@
+{
+  "input_file": "ebird_tracks_IN_2026-01-08.csv",
+  "input_sha256": "2d1e8ffb1e05a5a965a8d90c41a18003bc2af8baf93aad9c469980e956172fae",
+  "n_total_raw": 2313805,
+  "n_remove_not_in_ebd": 19227,
+  "n_keep_from_original": 2255901,
+  "n_swap_and_keep": 781,
+  "n_remove_outside_india": 37896
+}

--- a/00_scripts/01_assess_centroids.R
+++ b/00_scripts/01_assess_centroids.R
@@ -1,0 +1,122 @@
+# This script assesses the original centroids file for errors and makes
+# inclusion/exclusion decisions for each checklist.
+# Decisions are based on whether a checklist centroid location lies inside or
+# outside India and whether centroid locations fall back into India if latitude
+# and longitude are swapped. It produces an assessment report where each
+# checklist in the centroid file is assigned a decision and a
+# reason for it and a summary json file. 
+
+library(DBI)
+library(glue)
+library(jsonlite)
+library(digest)
+
+source("00_scripts/private.R")
+source("00_scripts/functions_centroids.R") # Load helper functions
+
+# Load Data ----
+load("00_data/maps_sf.RData")
+india_sf_4326 <- st_transform(india_sf, crs = 4326)
+
+raw_file_path <- "00_data/ebird_tracks_IN_2026-01-08.csv.zip"
+unzip(raw_file_path, exdir = "00_data")
+centroids_file_name <-
+  list.files(path = "00_data/",
+             pattern = "ebird_tracks_IN.*\\.csv$",
+             full.names = TRUE)[1]
+centroids <- read.csv(centroids_file_name, header = TRUE)
+
+# Validation file structure ----
+validate_centroid_schema(centroids)
+
+# Get location status (within/outside India) ----
+# Before and after swapping the centroid coordinates
+
+centroids$location_status <-
+  get_location_status(centroids,
+                      "centroid_longitude",
+                      "centroid_latitude",
+                      india_sf_4326)
+centroids$location_status_swapped <-
+  get_location_status(centroids,
+                      "centroid_latitude",
+                      "centroid_longitude",
+                      india_sf_4326)
+
+# Extract checklist id from database (if present) ----
+dbExecute(con, 
+          "CREATE TEMP TABLE temp_ids (
+          sampling_event_identifier text
+          ) ON COMMIT DROP")
+dbWriteTable(
+  con,
+  "temp_ids",
+  data.frame(sampling_event_identifier = centroids$checklist_id),
+  append = TRUE,
+  row.names = FALSE
+)
+
+
+# Add index (VERY important for millions of rows)
+# dbExecute(con, "
+#     CREATE INDEX idx_temp_ids
+#     ON temp_ids(sampling_event_identifier)
+# ")
+
+ebd_presence <-
+  dbGetQuery(
+    con,
+    "SELECT DISTINCT 
+    e.\"SAMPLING.EVENT.IDENTIFIER\" as checklist_id 
+    FROM ebd e 
+    INNER JOIN temp_ids t 
+    ON e.\"SAMPLING.EVENT.IDENTIFIER\" = t.sampling_event_identifier"
+  )
+
+centroids_ebd_check <- centroids %>%
+  mutate(list_found_in_ebd = checklist_id %in% ebd_presence$checklist_id)
+
+
+centroids_updated <- centroids_ebd_check %>%
+  mutate(action = case_when(
+    location_status == 1 & list_found_in_ebd == TRUE ~ "KEEP",
+    location_status == 1 & list_found_in_ebd == FALSE ~ "REMOVE_NOT_IN_EBD",
+    location_status == 0 &
+      location_status_swapped == 1 ~ "SWAP_AND_KEEP",
+    TRUE ~ "REMOVE_OUTSIDE_INDIA"
+  )
+  )
+
+
+# Write Report & Summary ----
+
+# Report CSV
+assessment_report <- centroids_updated %>%
+  dplyr::select(checklist_id,
+         action,
+         location_status,
+         location_status_swapped,
+         list_found_in_ebd)
+
+write.csv(assessment_report,
+          "00_data/centroids_assessment_report.csv",
+          row.names = FALSE)
+
+# Summary JSON
+summary_stats <- list(
+  input_file = basename(centroids_file_name),
+  input_sha256 = digest(centroids_file_name, algo = "sha256", file = TRUE),
+  n_total_raw = nrow(centroids_updated),
+  n_remove_not_in_ebd = sum(centroids_updated$action == "REMOVE_NOT_IN_EBD"),
+  n_keep_from_original = sum(centroids_updated$action == "KEEP"),
+  n_swap_and_keep = sum(centroids_updated$action == "SWAP_AND_KEEP"),
+  n_remove_outside_india = sum(centroids_updated$action == "REMOVE_OUTSIDE_INDIA")
+  
+)
+
+write_json(
+  summary_stats,
+  "00_data/centroids_assessment_summary.json",
+  auto_unbox = TRUE,
+  pretty = TRUE
+)

--- a/00_scripts/01_assess_centroids.R
+++ b/00_scripts/01_assess_centroids.R
@@ -76,13 +76,12 @@ ebd_presence <-
 centroids_ebd_check <- centroids %>%
   mutate(list_found_in_ebd = checklist_id %in% ebd_presence$checklist_id)
 
-
 centroids_updated <- centroids_ebd_check %>%
   mutate(action = case_when(
     location_status == 1 & list_found_in_ebd == TRUE ~ "KEEP",
     location_status == 1 & list_found_in_ebd == FALSE ~ "REMOVE_NOT_IN_EBD",
     location_status == 0 &
-      location_status_swapped == 1 ~ "SWAP_AND_KEEP",
+      location_status_swapped == 1 & list_found_in_ebd == TRUE ~ "SWAP_AND_KEEP",
     TRUE ~ "REMOVE_OUTSIDE_INDIA"
   )
   )
@@ -101,6 +100,7 @@ assessment_report <- centroids_updated %>%
 write.csv(assessment_report,
           "00_data/centroids_assessment_report.csv",
           row.names = FALSE)
+
 
 # Summary JSON
 summary_stats <- list(

--- a/00_scripts/02_sanitize_centroids.R
+++ b/00_scripts/02_sanitize_centroids.R
@@ -1,0 +1,120 @@
+# This script implements the decisions made in the assessment script 
+# (01_assess_centroids.R) and add a field called "location score" to
+# the original centroids file. Based on how far the checklist location 
+# specified in the EBD is from the bounding box, the location score
+# is assigned a value of 0 (inside the bounding box), 1 (less than
+# 2 km outside the bounding box), 2 (between 2 and 5 km from the bounding
+# box) and 3 (for all other distances)  
+
+library(DBI)
+library(glue)
+library(tidyverse)
+library(sf)
+library(digest)
+library(jsonlite)
+
+sf::sf_use_s2(FALSE)
+source("00_scripts/private.R")
+source("00_scripts/functions_centroids.R") # Load helper functions
+
+# Verify Integrity of the centroids file  ----
+summary_json <- read_json("00_data/centroids_assessment_summary.json")
+current_sha <- digest("00_data/ebird_tracks_IN_2026-01-08.csv", algo="sha256", file=TRUE)
+
+if (current_sha != summary_json$input_sha256) {
+  stop("Data integrity check failed! Input file has changed since assessment.")
+}
+
+# Read and filter ----
+report <- read.csv("00_data/centroids_assessment_report.csv")
+raw_data <- read.csv("00_data/ebird_tracks_IN_2026-01-08.csv")
+
+# Only keep valid checklists
+centroids_to_process <- report %>% 
+  filter(action %in% c("KEEP", "SWAP_AND_KEEP") & 
+           list_found_in_ebd == TRUE) %>%
+  left_join(raw_data, by = "checklist_id")
+
+# Make new columns for swapped coordinates ----
+centroids_sanitized <- centroids_to_process %>%
+  mutate(
+    # Swap centroids if action is SWAP_AND_KEEP
+    final_centroid_lat = if_else(action == "SWAP_AND_KEEP", centroid_longitude, centroid_latitude),
+    final_centroid_lon = if_else(action == "SWAP_AND_KEEP", centroid_latitude, centroid_longitude),
+    # Swap bounding box coordinates
+    final_lat_min = if_else(action == "SWAP_AND_KEEP", longitude_min, latitude_min),
+    final_lat_max = if_else(action == "SWAP_AND_KEEP", longitude_max, latitude_max),
+    final_lon_min = if_else(action == "SWAP_AND_KEEP", latitude_min, longitude_min),
+    final_lon_max = if_else(action == "SWAP_AND_KEEP", latitude_max, longitude_max)
+  ) 
+# %>%
+#   separate(obs_dt, into = c("date", "time"), sep = " ")
+
+# Pull EBD Columns ----
+dbExecute(con, 
+          "CREATE TEMP TABLE clean_ids (sampling_event_identifier text) ON COMMIT DROP")
+dbWriteTable(con, 
+             "clean_ids", 
+             data.frame(
+               sampling_event_identifier = 
+                 centroids_sanitized$checklist_id), 
+             append = TRUE, row.names = FALSE)
+
+qry <- glue('
+SELECT DISTINCT
+    e."LOCALITY.ID",
+    e."LOCALITY.TYPE",
+    e."STATE",
+    e."COUNTY",
+    e."LATITUDE",
+    e."LONGITUDE",
+    e."DURATION.MINUTES",
+    e."EFFORT.DISTANCE.KM",
+    e."SAMPLING.EVENT.IDENTIFIER"
+FROM ebd e
+INNER JOIN clean_ids t
+ON e."SAMPLING.EVENT.IDENTIFIER" =
+   t.sampling_event_identifier
+')
+
+ebd_columns <- dbGetQuery(con,
+                       qry)
+
+
+centroids_sanitized_ebd_col <- centroids_sanitized %>%
+  left_join(ebd_columns, 
+            by = join_by(checklist_id == SAMPLING.EVENT.IDENTIFIER)
+  )
+
+
+saveRDS(centroids_sanitized_ebd_col, file = "00_data/centroids_sanitized_ebd_col_wo_dist.rds")
+
+
+centroids_sanitized_ebd_col$dist_meters <- compute_bbox_distance(centroids_sanitized_ebd_col,
+                                                                 "final_lon_min",
+                                                                 "final_lon_max",
+                                                                 "final_lat_min",
+                                                                 "final_lat_max",
+                                                                 "LONGITUDE",
+                                                                 "LATITUDE")
+
+
+saveRDS(centroids_sanitized_ebd_col, file = "00_data/centroids_sanitized_ebd_col_dist.rds")
+
+# Final Scoring and Output ----
+final_output <- centroids_sanitized_ebd_col %>%
+  mutate(
+    location_score = calculate_location_score(dist_meters/1000)
+  ) %>%
+  select(
+    checklist_id, obs_dt, 
+    longitude_min = final_lon_min, longitude_max = final_lon_max, 
+    latitude_min = final_lat_min, latitude_max = final_lat_max, 
+    centroid_longitude = final_lon_min, centroid_latitude = final_lat_min,
+    location_score
+  )
+
+write.csv(final_output, "00_data/centroids_sanitized_final.csv", row.names = FALSE)
+
+saveRDS(final_output, file = "00_data/centroids_sanitized_final.rds")
+

--- a/00_scripts/02_sanitize_centroids.R
+++ b/00_scripts/02_sanitize_centroids.R
@@ -30,9 +30,8 @@ report <- read.csv("00_data/centroids_assessment_report.csv")
 raw_data <- read.csv("00_data/ebird_tracks_IN_2026-01-08.csv")
 
 # Only keep valid checklists
-centroids_to_process <- report %>% 
-  filter(action %in% c("KEEP", "SWAP_AND_KEEP") & 
-           list_found_in_ebd == TRUE) %>%
+centroids_to_process <- report_1 %>% 
+  filter(action %in% c("KEEP", "SWAP_AND_KEEP")) %>%
   left_join(raw_data, by = "checklist_id")
 
 # Make new columns for swapped coordinates ----

--- a/00_scripts/functions_centroids.R
+++ b/00_scripts/functions_centroids.R
@@ -1,0 +1,85 @@
+# Helper functions
+
+library(sf)
+library(tidyverse)
+
+
+# Determine if points fall within a specific region ----
+get_location_status <- function(df, lon_col, lat_col, region_sf) {
+  sf_obj <- tryCatch({
+    st_as_sf(df, coords = c(lon_col, lat_col), crs = 4326)
+  }, error = function(e) NULL)
+  
+  if (is.null(sf_obj)) return(rep(0, nrow(df)))
+  return(lengths(st_intersects(sf_obj, region_sf)))
+}
+
+# Calculate perpendicular distance from checklist location to bounding box ----
+compute_bbox_distance <- 
+  function(df, lon_min, lon_max, lat_min, lat_max, actual_lon, actual_lat) {
+  # Checklist locations as points
+  pts <- st_as_sf(df, coords = c(actual_lon, actual_lat), crs = 4326)
+  
+  # Bounding boxes as polygons
+  boxes <- st_sfc(purrr::pmap(
+    list(df[[lon_min]], df[[lon_max]], df[[lat_min]], df[[lat_max]]),
+    function(xmin, xmax, ymin, ymax) {
+      st_polygon(list(matrix(c(xmin, ymin, xmax, ymin, xmax, ymax, xmin, ymax, xmin, ymin), 
+                             ncol = 2, byrow = TRUE)))
+    }
+  ), crs = 4326)
+  
+  return(as.numeric(st_distance(pts, boxes, by_element = TRUE)))
+}
+
+# Checking centroid file for errors ----
+
+validate_centroid_schema <- function(df) {
+  errors <- character() # A vector to collect all error messages
+  
+  expected_cols <- c("checklist_id", "obs_dt", "longitude_min", "longitude_max", 
+                     "latitude_min", "latitude_max", "centroid_longitude", "centroid_latitude")
+  
+  # Check if expected columns are present
+  missing <- setdiff(expected_cols, names(df))
+  if (length(missing) > 0) {
+    errors <- c(errors, paste("Missing columns:", paste(missing, collapse = ", ")))
+  }
+  
+  # Check data type
+  if (!is.character(df$checklist_id)) errors <- c(errors, "checklist_id must be character")
+  
+  coord_cols <- c("longitude_min", "longitude_max", "latitude_min", "latitude_max", 
+                  "centroid_longitude", "centroid_latitude")
+  
+  bad_types <- coord_cols[!sapply(df[coord_cols], is.numeric)]
+  if (length(bad_types) > 0) {
+    errors <- c(errors, paste("Non-numeric columns:", paste(bad_types, collapse = ", ")))
+  }
+  
+  # Check for missing values
+  na_cols <- names(which(colSums(is.na(df)) > 0))
+  if (length(na_cols) > 0) {
+    errors <- c(errors, paste("NAs found in:", paste(na_cols, collapse = ", ")))
+  }
+  
+
+  if (length(errors) > 0) {
+    # Combine all errors into one message and stop
+    stop("\n--- SCHEMA VALIDATION FAILED ---\n", paste("-", errors, collapse = "\n"))
+  }
+  
+  return(TRUE)
+}
+
+# --- Scoring a checklist ---
+
+# Assign score based on distance in kilometers
+calculate_location_score <- function(dist_km) {
+  case_when(
+    dist_km == 0 ~ 0,
+    dist_km < 2  ~ 1,
+    dist_km > 2 & dist_km < 5 ~ 2,
+    TRUE ~ 3
+  )
+}


### PR DESCRIPTION
 This is done in two steps -

1. assessing the file and making decisions about inclusion/exclusion of checklists and
2. Implementing these decisions and assigning a score to retained checklists based on how far away the user-specified location (EBD location) is from the centroid bounding box. The location score is currently assigned values 0,1,2 and 3 for inside the bounding box, less than 2 km from the bounding box, between 2 and 5 km from the bounding box and beyond 5 km. 
