### PR TITLE
Picking randomgroupids from the correct location while creating a job package for cloud or HPC runs

### DIFF
--- a/60_cloud_helpers/setup-species-run.py
+++ b/60_cloud_helpers/setup-species-run.py
@@ -129,11 +129,22 @@ for fname in ['dataforanalyses.RData-data_opt',
     print(f"{src_fname} -> {tgt_fname}")
     shutil.copy(src_fname, tgt_fname)
 
-print(f'Copying {num_assignments}({assignment_min}:{assignment_max}) random group ids from ../{mask_dir} to {tgt_mask_dir}')
+# print(f'Copying {num_assignments}({assignment_min}:{assignment_max}) random group ids from ../{mask_dir} to {tgt_mask_dir}')
+# for i in range(assignment_min,assignment_max+1):
+#     rgid = f"rgids-{i}.RData"
+#     src_fname = os.path.join('..',mask_dir, rgid)
+#     tgt_fname = os.path.join(tgt_mask_dir,rgid)
+#     shutil.copy(src_fname, tgt_fname)
+
+rgid_subdir = "randomgroupids"
+src_rgid_dir = os.path.join('..', mask_dir, rgid_subdir)
+tgt_rgid_dir = os.path.join(tgt_mask_dir, rgid_subdir)
+Path(tgt_rgid_dir).mkdir(parents=True, exist_ok=True)
+print(f'Copying {num_assignments}({assignment_min}:{assignment_max}) random group ids from {src_rgid_dir} to {tgt_rgid_dir}')
 for i in range(assignment_min,assignment_max+1):
     rgid = f"rgids-{i}.RData"
-    src_fname = os.path.join('..',mask_dir, rgid)
-    tgt_fname = os.path.join(tgt_mask_dir,rgid)
+    src_fname = os.path.join(src_rgid_dir, rgid)
+    tgt_fname = os.path.join(tgt_rgid_dir, rgid)
     shutil.copy(src_fname, tgt_fname)
 
 print("Copying common data files")

--- a/60_cloud_helpers/setup-species-run.py
+++ b/60_cloud_helpers/setup-species-run.py
@@ -129,13 +129,6 @@ for fname in ['dataforanalyses.RData-data_opt',
     print(f"{src_fname} -> {tgt_fname}")
     shutil.copy(src_fname, tgt_fname)
 
-# print(f'Copying {num_assignments}({assignment_min}:{assignment_max}) random group ids from ../{mask_dir} to {tgt_mask_dir}')
-# for i in range(assignment_min,assignment_max+1):
-#     rgid = f"rgids-{i}.RData"
-#     src_fname = os.path.join('..',mask_dir, rgid)
-#     tgt_fname = os.path.join(tgt_mask_dir,rgid)
-#     shutil.copy(src_fname, tgt_fname)
-
 rgid_subdir = "randomgroupids"
 src_rgid_dir = os.path.join('..', mask_dir, rgid_subdir)
 tgt_rgid_dir = os.path.join(tgt_mask_dir, rgid_subdir)


### PR DESCRIPTION
The path to the randomgroupids has changed since the scripts to create job packages were first written. This PR contains changes such that the new paths are used. The new script has been tested and is able to return a job package without errors.